### PR TITLE
feat(content): provide the latest production code from dawn's repository and fix prose.io integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ email_contacts:
 # Github Repo for Data
 # Replace this value as needed.
 repo_name: open-sdg-data-starter
-branch: develop
+branch: development
 # Replace this value as needed.
 org_name: CityOfLosAngeles 
 

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,8 @@ title: City of Los Angeles Indicators For The Sustainable Development Goals
 baseurl: ""
 url: ""
 data_dir: data
-environment: development
+# environment must be set to staging to toggle the edit buttions for prose.io
+environment: staging
 # Replace MY-GITHUB-ORG and OPEN-SDG-DATA-STARTER as needed.
 remote_data_prefix: "https://d26ib27epzwu9e.cloudfront.net"
 remote_translations:
@@ -26,7 +27,6 @@ create_indicators:
 create_goals:
   layout: goal-by-target
 create_pages: true
-
 
 analytics:
   ga_prod: ''

--- a/_goals/01_no-poverty.md
+++ b/_goals/01_no-poverty.md
@@ -1,7 +1,0 @@
----
-permalink: /1/
-sdg_goal: '1'
-color: '#e5243b'
-layout: goal-by-target
----
-

--- a/_goals/02_zero-hunger.md
+++ b/_goals/02_zero-hunger.md
@@ -1,7 +1,0 @@
----
-permalink: /2/
-sdg_goal: '2'
-color: '#e5b735'
-layout: goal-by-target
----
-

--- a/_goals/03_good-health-and-well-being.md
+++ b/_goals/03_good-health-and-well-being.md
@@ -1,7 +1,0 @@
----
-permalink: /3/
-sdg_goal: '3'
-color: '#4c9f38'
-layout: goal-by-target
----
-

--- a/_goals/04_quality-education.md
+++ b/_goals/04_quality-education.md
@@ -1,7 +1,0 @@
----
-permalink: /4/
-sdg_goal: '4'
-color: '#c5192d'
-layout: goal-by-target
----
-

--- a/_goals/05_gender-equality.md
+++ b/_goals/05_gender-equality.md
@@ -1,7 +1,0 @@
----
-permalink: /5/
-sdg_goal: '5'
-color: '#ff3a21'
-layout: goal-by-target
----
-

--- a/_goals/06_clean-water-and-sanitation.md
+++ b/_goals/06_clean-water-and-sanitation.md
@@ -1,7 +1,0 @@
----
-permalink: /6/
-sdg_goal: '6'
-color: '#26bde2'
-layout: goal-by-target
----
-

--- a/_goals/07_affordable-and-clean-energy.md
+++ b/_goals/07_affordable-and-clean-energy.md
@@ -1,7 +1,0 @@
----
-permalink: /7/
-sdg_goal: '7'
-color: '#fcc30b'
-layout: goal-by-target
----
-

--- a/_goals/08_decent-jobs-and-economic-growth.md
+++ b/_goals/08_decent-jobs-and-economic-growth.md
@@ -1,7 +1,0 @@
----
-permalink: /8/
-sdg_goal: '8'
-color: '#a21942'
-layout: goal-by-target
----
-

--- a/_goals/09_industry-innovation-and-infrastructure.md
+++ b/_goals/09_industry-innovation-and-infrastructure.md
@@ -1,7 +1,0 @@
----
-permalink: /9/
-sdg_goal: '9'
-color: '#fd6925'
-layout: goal-by-target
----
-

--- a/_goals/10_reduced-inequalities.md
+++ b/_goals/10_reduced-inequalities.md
@@ -1,7 +1,0 @@
----
-permalink: /10/
-sdg_goal: '10'
-color: '#dd1367'
-layout: goal-by-target
----
-

--- a/_goals/11_sustainable-cities-communities.md
+++ b/_goals/11_sustainable-cities-communities.md
@@ -1,7 +1,0 @@
----
-permalink: /11/
-sdg_goal: '11'
-color: '#fd9d24'
-layout: goal-by-target
----
-

--- a/_goals/12_responsible-consumption-and-production.md
+++ b/_goals/12_responsible-consumption-and-production.md
@@ -1,7 +1,0 @@
----
-permalink: /12/
-sdg_goal: '12'
-color: '#c9992d'
-layout: goal-by-target
----
-

--- a/_goals/13_climate-action.md
+++ b/_goals/13_climate-action.md
@@ -1,7 +1,0 @@
----
-permalink: /13/
-sdg_goal: '13'
-color: '#3f7e44'
-layout: goal-by-target
----
-

--- a/_goals/14_life-below-water.md
+++ b/_goals/14_life-below-water.md
@@ -1,7 +1,0 @@
----
-permalink: /14/
-sdg_goal: '14'
-color: '#0a97d9'
-layout: goal-by-target
----
-

--- a/_goals/15_life-on-land.md
+++ b/_goals/15_life-on-land.md
@@ -1,7 +1,0 @@
----
-permalink: /15/
-sdg_goal: '15'
-color: '#56c02b'
-layout: goal-by-target
----
-

--- a/_goals/16_peace-and-justice-strong-institutions.md
+++ b/_goals/16_peace-and-justice-strong-institutions.md
@@ -1,7 +1,0 @@
----
-permalink: /16/
-sdg_goal: '16'
-color: '#00689d'
-layout: goal-by-target
----
-

--- a/_goals/17_partnerships-for-the-goals.md
+++ b/_goals/17_partnerships-for-the-goals.md
@@ -1,7 +1,0 @@
----
-permalink: /17/
-sdg_goal: '17'
-color: '#19486a'
-layout: goal-by-target
----
-

--- a/_indicators/1-1-1.md
+++ b/_indicators/1-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 1.1.1
-layout: indicator
-permalink: /1-1-1/
----
-
-

--- a/_indicators/1-2-1.md
+++ b/_indicators/1-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 1.2.1
-layout: indicator
-permalink: /1-2-1/
----
-
-

--- a/_indicators/1-2-2.md
+++ b/_indicators/1-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 1.2.2
-layout: indicator
-permalink: /1-2-2/
----
-
-

--- a/_indicators/1-3-1.md
+++ b/_indicators/1-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 1.3.1
-layout: indicator
-permalink: /1-3-1/
----
-
-

--- a/_indicators/1-4-1.md
+++ b/_indicators/1-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 1.4.1
-layout: indicator
-permalink: /1-4-1/
----
-
-

--- a/_indicators/1-4-2.md
+++ b/_indicators/1-4-2.md
@@ -1,7 +1,0 @@
----
-indicator: 1.4.2
-layout: indicator
-permalink: /1-4-2/
----
-
-

--- a/_indicators/1-5-1.md
+++ b/_indicators/1-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 1.5.1
-layout: indicator
-permalink: /1-5-1/
----
-
-

--- a/_indicators/1-5-2.md
+++ b/_indicators/1-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 1.5.2
-layout: indicator
-permalink: /1-5-2/
----
-
-

--- a/_indicators/1-5-3.md
+++ b/_indicators/1-5-3.md
@@ -1,7 +1,0 @@
----
-indicator: 1.5.3
-layout: indicator
-permalink: /1-5-3/
----
-
-

--- a/_indicators/1-5-4.md
+++ b/_indicators/1-5-4.md
@@ -1,7 +1,0 @@
----
-indicator: 1.5.4
-layout: indicator
-permalink: /1-5-4/
----
-
-

--- a/_indicators/1-a-1.md
+++ b/_indicators/1-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 1.a.1
-layout: indicator
-permalink: /1-a-1/
----
-
-

--- a/_indicators/1-a-2.md
+++ b/_indicators/1-a-2.md
@@ -1,7 +1,0 @@
----
-indicator: 1.a.2
-layout: indicator
-permalink: /1-a-2/
----
-
-

--- a/_indicators/1-a-3.md
+++ b/_indicators/1-a-3.md
@@ -1,7 +1,0 @@
----
-indicator: 1.a.3
-layout: indicator
-permalink: /1-a-3/
----
-
-

--- a/_indicators/1-b-1.md
+++ b/_indicators/1-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 1.b.1
-layout: indicator
-permalink: /1-b-1/
----
-
-

--- a/_indicators/10-1-1.md
+++ b/_indicators/10-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 10.1.1
-layout: indicator
-permalink: /10-1-1/
----
-
-

--- a/_indicators/10-2-1.md
+++ b/_indicators/10-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 10.2.1
-layout: indicator
-permalink: /10-2-1/
----
-
-

--- a/_indicators/10-3-1.md
+++ b/_indicators/10-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 10.3.1
-layout: indicator
-permalink: /10-3-1/
----
-
-

--- a/_indicators/10-4-1.md
+++ b/_indicators/10-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 10.4.1
-layout: indicator
-permalink: /10-4-1/
----
-
-

--- a/_indicators/10-6-1.md
+++ b/_indicators/10-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 10.6.1
-layout: indicator
-permalink: /10-6-1/
----
-
-

--- a/_indicators/10-7-1.md
+++ b/_indicators/10-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 10.7.1
-layout: indicator
-permalink: /10-7-1/
----
-
-

--- a/_indicators/10-7-2.md
+++ b/_indicators/10-7-2.md
@@ -1,7 +1,0 @@
----
-indicator: 10.7.2
-layout: indicator
-permalink: /10-7-2/
----
-
-

--- a/_indicators/11-1-1.md
+++ b/_indicators/11-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.1.1
-layout: indicator
-permalink: /11-1-1/
----
-
-

--- a/_indicators/11-2-1.md
+++ b/_indicators/11-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.2.1
-layout: indicator
-permalink: /11-2-1/
----
-
-

--- a/_indicators/11-3-1.md
+++ b/_indicators/11-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.3.1
-layout: indicator
-permalink: /11-3-1/
----
-
-

--- a/_indicators/11-3-2.md
+++ b/_indicators/11-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 11.3.2
-layout: indicator
-permalink: /11-3-2/
----
-
-

--- a/_indicators/11-4-1.md
+++ b/_indicators/11-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.4.1
-layout: indicator
-permalink: /11-4-1/
----
-
-

--- a/_indicators/11-5-1.md
+++ b/_indicators/11-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.5.1
-layout: indicator
-permalink: /11-5-1/
----
-
-

--- a/_indicators/11-5-2.md
+++ b/_indicators/11-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 11.5.2
-layout: indicator
-permalink: /11-5-2/
----
-
-

--- a/_indicators/11-6-1.md
+++ b/_indicators/11-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.6.1
-layout: indicator
-permalink: /11-6-1/
----
-
-

--- a/_indicators/11-6-2.md
+++ b/_indicators/11-6-2.md
@@ -1,7 +1,0 @@
----
-indicator: 11.6.2
-layout: indicator
-permalink: /11-6-2/
----
-
-

--- a/_indicators/11-7-1.md
+++ b/_indicators/11-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.7.1
-layout: indicator
-permalink: /11-7-1/
----
-
-

--- a/_indicators/11-7-2.md
+++ b/_indicators/11-7-2.md
@@ -1,7 +1,0 @@
----
-indicator: 11.7.2
-layout: indicator
-permalink: /11-7-2/
----
-
-

--- a/_indicators/11-a-1.md
+++ b/_indicators/11-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.a.1
-layout: indicator
-permalink: /11-a-1/
----
-
-

--- a/_indicators/11-b-1.md
+++ b/_indicators/11-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.b.1
-layout: indicator
-permalink: /11-b-1/
----
-
-

--- a/_indicators/11-b-2.md
+++ b/_indicators/11-b-2.md
@@ -1,7 +1,0 @@
----
-indicator: 11.b.2
-layout: indicator
-permalink: /11-b-2/
----
-
-

--- a/_indicators/11-c-1.md
+++ b/_indicators/11-c-1.md
@@ -1,7 +1,0 @@
----
-indicator: 11.c.1
-layout: indicator
-permalink: /11-c-1/
----
-
-

--- a/_indicators/12-1-1.md
+++ b/_indicators/12-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.1.1
-layout: indicator
-permalink: /12-1-1/
----
-
-

--- a/_indicators/12-2-1.md
+++ b/_indicators/12-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.2.1
-layout: indicator
-permalink: /12-2-1/
----
-
-

--- a/_indicators/12-2-2.md
+++ b/_indicators/12-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 12.2.2
-layout: indicator
-permalink: /12-2-2/
----
-
-

--- a/_indicators/12-3-1.md
+++ b/_indicators/12-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.3.1
-layout: indicator
-permalink: /12-3-1/
----
-
-

--- a/_indicators/12-4-1.md
+++ b/_indicators/12-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.4.1
-layout: indicator
-permalink: /12-4-1/
----
-
-

--- a/_indicators/12-4-2.md
+++ b/_indicators/12-4-2.md
@@ -1,7 +1,0 @@
----
-indicator: 12.4.2
-layout: indicator
-permalink: /12-4-2/
----
-
-

--- a/_indicators/12-5-1.md
+++ b/_indicators/12-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.5.1
-layout: indicator
-permalink: /12-5-1/
----
-
-

--- a/_indicators/12-6-1.md
+++ b/_indicators/12-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.6.1
-layout: indicator
-permalink: /12-6-1/
----
-
-

--- a/_indicators/12-7-1.md
+++ b/_indicators/12-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.7.1
-layout: indicator
-permalink: /12-7-1/
----
-
-

--- a/_indicators/12-8-1.md
+++ b/_indicators/12-8-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.8.1
-layout: indicator
-permalink: /12-8-1/
----
-
-

--- a/_indicators/12-a-1.md
+++ b/_indicators/12-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.a.1
-layout: indicator
-permalink: /12-a-1/
----
-
-

--- a/_indicators/12-b-1.md
+++ b/_indicators/12-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.b.1
-layout: indicator
-permalink: /12-b-1/
----
-
-

--- a/_indicators/12-c-1.md
+++ b/_indicators/12-c-1.md
@@ -1,7 +1,0 @@
----
-indicator: 12.c.1
-layout: indicator
-permalink: /12-c-1/
----
-
-

--- a/_indicators/13-1-1.md
+++ b/_indicators/13-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 13.1.1
-layout: indicator
-permalink: /13-1-1/
----
-
-

--- a/_indicators/13-1-2.md
+++ b/_indicators/13-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 13.1.2
-layout: indicator
-permalink: /13-1-2/
----
-
-

--- a/_indicators/13-1-3.md
+++ b/_indicators/13-1-3.md
@@ -1,7 +1,0 @@
----
-indicator: 13.1.3
-layout: indicator
-permalink: /13-1-3/
----
-
-

--- a/_indicators/13-2-1.md
+++ b/_indicators/13-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 13.2.1
-layout: indicator
-permalink: /13-2-1/
----
-
-

--- a/_indicators/13-3-1.md
+++ b/_indicators/13-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 13.3.1
-layout: indicator
-permalink: /13-3-1/
----
-
-

--- a/_indicators/13-3-2.md
+++ b/_indicators/13-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 13.3.2
-layout: indicator
-permalink: /13-3-2/
----
-
-

--- a/_indicators/13-b-1.md
+++ b/_indicators/13-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 13.b.1
-layout: indicator
-permalink: /13-b-1/
----
-
-

--- a/_indicators/14-1-1.md
+++ b/_indicators/14-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.1.1
-layout: indicator
-permalink: /14-1-1/
----
-
-

--- a/_indicators/14-2-1.md
+++ b/_indicators/14-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.2.1
-layout: indicator
-permalink: /14-2-1/
----
-
-

--- a/_indicators/14-3-1.md
+++ b/_indicators/14-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.3.1
-layout: indicator
-permalink: /14-3-1/
----
-
-

--- a/_indicators/14-4-1.md
+++ b/_indicators/14-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.4.1
-layout: indicator
-permalink: /14-4-1/
----
-
-

--- a/_indicators/14-5-1.md
+++ b/_indicators/14-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.5.1
-layout: indicator
-permalink: /14-5-1/
----
-
-

--- a/_indicators/14-7-1.md
+++ b/_indicators/14-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.7.1
-layout: indicator
-permalink: /14-7-1/
----
-
-

--- a/_indicators/14-a-1.md
+++ b/_indicators/14-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.a.1
-layout: indicator
-permalink: /14-a-1/
----
-
-

--- a/_indicators/14-b-1.md
+++ b/_indicators/14-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.b.1
-layout: indicator
-permalink: /14-b-1/
----
-
-

--- a/_indicators/14-c-1.md
+++ b/_indicators/14-c-1.md
@@ -1,7 +1,0 @@
----
-indicator: 14.c.1
-layout: indicator
-permalink: /14-c-1/
----
-
-

--- a/_indicators/15-1-1.md
+++ b/_indicators/15-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.1.1
-layout: indicator
-permalink: /15-1-1/
----
-
-

--- a/_indicators/15-1-2.md
+++ b/_indicators/15-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 15.1.2
-layout: indicator
-permalink: /15-1-2/
----
-
-

--- a/_indicators/15-2-1.md
+++ b/_indicators/15-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.2.1
-layout: indicator
-permalink: /15-2-1/
----
-
-

--- a/_indicators/15-3-1.md
+++ b/_indicators/15-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.3.1
-layout: indicator
-permalink: /15-3-1/
----
-
-

--- a/_indicators/15-4-1.md
+++ b/_indicators/15-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.4.1
-layout: indicator
-permalink: /15-4-1/
----
-
-

--- a/_indicators/15-4-2.md
+++ b/_indicators/15-4-2.md
@@ -1,7 +1,0 @@
----
-indicator: 15.4.2
-layout: indicator
-permalink: /15-4-2/
----
-
-

--- a/_indicators/15-5-1.md
+++ b/_indicators/15-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.5.1
-layout: indicator
-permalink: /15-5-1/
----
-
-

--- a/_indicators/15-6-1.md
+++ b/_indicators/15-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.6.1
-layout: indicator
-permalink: /15-6-1/
----
-
-

--- a/_indicators/15-7-1.md
+++ b/_indicators/15-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.7.1
-layout: indicator
-permalink: /15-7-1/
----
-
-

--- a/_indicators/15-8-1.md
+++ b/_indicators/15-8-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.8.1
-layout: indicator
-permalink: /15-8-1/
----
-
-

--- a/_indicators/15-9-1.md
+++ b/_indicators/15-9-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.9.1
-layout: indicator
-permalink: /15-9-1/
----
-
-

--- a/_indicators/15-a-1.md
+++ b/_indicators/15-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.a.1
-layout: indicator
-permalink: /15-a-1/
----
-
-

--- a/_indicators/15-b-1.md
+++ b/_indicators/15-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.b.1
-layout: indicator
-permalink: /15-b-1/
----
-
-

--- a/_indicators/15-c-1.md
+++ b/_indicators/15-c-1.md
@@ -1,7 +1,0 @@
----
-indicator: 15.c.1
-layout: indicator
-permalink: /15-c-1/
----
-
-

--- a/_indicators/16-1-1.md
+++ b/_indicators/16-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.1.1
-layout: indicator
-permalink: /16-1-1/
----
-
-

--- a/_indicators/16-1-2.md
+++ b/_indicators/16-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.1.2
-layout: indicator
-permalink: /16-1-2/
----
-
-

--- a/_indicators/16-1-3.md
+++ b/_indicators/16-1-3.md
@@ -1,7 +1,0 @@
----
-indicator: 16.1.3
-layout: indicator
-permalink: /16-1-3/
----
-
-

--- a/_indicators/16-1-4.md
+++ b/_indicators/16-1-4.md
@@ -1,7 +1,0 @@
----
-indicator: 16.1.4
-layout: indicator
-permalink: /16-1-4/
----
-
-

--- a/_indicators/16-10-1.md
+++ b/_indicators/16-10-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.10.1
-layout: indicator
-permalink: /16-10-1/
----
-
-

--- a/_indicators/16-10-2.md
+++ b/_indicators/16-10-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.10.2
-layout: indicator
-permalink: /16-10-2/
----
-
-

--- a/_indicators/16-2-1.md
+++ b/_indicators/16-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.2.1
-layout: indicator
-permalink: /16-2-1/
----
-
-

--- a/_indicators/16-2-2.md
+++ b/_indicators/16-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.2.2
-layout: indicator
-permalink: /16-2-2/
----
-
-

--- a/_indicators/16-2-3.md
+++ b/_indicators/16-2-3.md
@@ -1,7 +1,0 @@
----
-indicator: 16.2.3
-layout: indicator
-permalink: /16-2-3/
----
-
-

--- a/_indicators/16-3-1.md
+++ b/_indicators/16-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.3.1
-layout: indicator
-permalink: /16-3-1/
----
-
-

--- a/_indicators/16-3-2.md
+++ b/_indicators/16-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.3.2
-layout: indicator
-permalink: /16-3-2/
----
-
-

--- a/_indicators/16-4-1.md
+++ b/_indicators/16-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.4.1
-layout: indicator
-permalink: /16-4-1/
----
-
-

--- a/_indicators/16-4-2.md
+++ b/_indicators/16-4-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.4.2
-layout: indicator
-permalink: /16-4-2/
----
-
-

--- a/_indicators/16-5-1.md
+++ b/_indicators/16-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.5.1
-layout: indicator
-permalink: /16-5-1/
----
-
-

--- a/_indicators/16-5-2.md
+++ b/_indicators/16-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.5.2
-layout: indicator
-permalink: /16-5-2/
----
-
-

--- a/_indicators/16-6-1.md
+++ b/_indicators/16-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.6.1
-layout: indicator
-permalink: /16-6-1/
----
-
-

--- a/_indicators/16-6-2.md
+++ b/_indicators/16-6-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.6.2
-layout: indicator
-permalink: /16-6-2/
----
-
-

--- a/_indicators/16-7-1.md
+++ b/_indicators/16-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.7.1
-layout: indicator
-permalink: /16-7-1/
----
-
-

--- a/_indicators/16-7-2.md
+++ b/_indicators/16-7-2.md
@@ -1,7 +1,0 @@
----
-indicator: 16.7.2
-layout: indicator
-permalink: /16-7-2/
----
-
-

--- a/_indicators/16-8-1.md
+++ b/_indicators/16-8-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.8.1
-layout: indicator
-permalink: /16-8-1/
----
-
-

--- a/_indicators/16-8-2.md
+++ b/_indicators/16-8-2.md
@@ -1,6 +1,0 @@
----
-indicator: 16.8.2
-layout: indicator
-permalink: /16-8-2/
----
-

--- a/_indicators/16-9-1.md
+++ b/_indicators/16-9-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.9.1
-layout: indicator
-permalink: /16-9-1/
----
-
-

--- a/_indicators/16-a-1.md
+++ b/_indicators/16-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.a.1
-layout: indicator
-permalink: /16-a-1/
----
-
-

--- a/_indicators/16-b-1.md
+++ b/_indicators/16-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 16.b.1
-layout: indicator
-permalink: /16-b-1/
----
-
-

--- a/_indicators/17-1-1.md
+++ b/_indicators/17-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.1.1
-layout: indicator
-permalink: /17-1-1/
----
-
-

--- a/_indicators/17-1-2.md
+++ b/_indicators/17-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 17.1.2
-layout: indicator
-permalink: /17-1-2/
----
-
-

--- a/_indicators/17-10-1.md
+++ b/_indicators/17-10-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.10.1
-layout: indicator
-permalink: /17-10-1/
----
-
-

--- a/_indicators/17-11-1.md
+++ b/_indicators/17-11-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.11.1
-layout: indicator
-permalink: /17-11-1/
----
-
-

--- a/_indicators/17-12-1.md
+++ b/_indicators/17-12-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.12.1
-layout: indicator
-permalink: /17-12-1/
----
-
-

--- a/_indicators/17-13-1.md
+++ b/_indicators/17-13-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.13.1
-layout: indicator
-permalink: /17-13-1/
----
-
-

--- a/_indicators/17-14-1.md
+++ b/_indicators/17-14-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.14.1
-layout: indicator
-permalink: /17-14-1/
----
-
-

--- a/_indicators/17-15-1.md
+++ b/_indicators/17-15-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.15.1
-layout: indicator
-permalink: /17-15-1/
----
-
-

--- a/_indicators/17-16-1.md
+++ b/_indicators/17-16-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.16.1
-layout: indicator
-permalink: /17-16-1/
----
-
-

--- a/_indicators/17-17-1.md
+++ b/_indicators/17-17-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.17.1
-layout: indicator
-permalink: /17-17-1/
----
-
-

--- a/_indicators/17-18-1.md
+++ b/_indicators/17-18-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.18.1
-layout: indicator
-permalink: /17-18-1/
----
-
-

--- a/_indicators/17-18-2.md
+++ b/_indicators/17-18-2.md
@@ -1,7 +1,0 @@
----
-indicator: 17.18.2
-layout: indicator
-permalink: /17-18-2/
----
-
-

--- a/_indicators/17-18-3.md
+++ b/_indicators/17-18-3.md
@@ -1,7 +1,0 @@
----
-indicator: 17.18.3
-layout: indicator
-permalink: /17-18-3/
----
-
-

--- a/_indicators/17-19-1.md
+++ b/_indicators/17-19-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.19.1
-layout: indicator
-permalink: /17-19-1/
----
-
-

--- a/_indicators/17-19-2.md
+++ b/_indicators/17-19-2.md
@@ -1,7 +1,0 @@
----
-indicator: 17.19.2
-layout: indicator
-permalink: /17-19-2/
----
-
-

--- a/_indicators/17-3-1.md
+++ b/_indicators/17-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.3.1
-layout: indicator
-permalink: /17-3-1/
----
-
-

--- a/_indicators/17-3-2.md
+++ b/_indicators/17-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 17.3.2
-layout: indicator
-permalink: /17-3-2/
----
-
-

--- a/_indicators/17-5-1.md
+++ b/_indicators/17-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.5.1
-layout: indicator
-permalink: /17-5-1/
----
-
-

--- a/_indicators/17-6-1.md
+++ b/_indicators/17-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.6.1
-layout: indicator
-permalink: /17-6-1/
----
-
-

--- a/_indicators/17-6-2.md
+++ b/_indicators/17-6-2.md
@@ -1,7 +1,0 @@
----
-indicator: 17.6.2
-layout: indicator
-permalink: /17-6-2/
----
-
-

--- a/_indicators/17-7-1.md
+++ b/_indicators/17-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.7.1
-layout: indicator
-permalink: /17-7-1/
----
-
-

--- a/_indicators/17-8-1.md
+++ b/_indicators/17-8-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.8.1
-layout: indicator
-permalink: /17-8-1/
----
-
-

--- a/_indicators/17-9-1.md
+++ b/_indicators/17-9-1.md
@@ -1,7 +1,0 @@
----
-indicator: 17.9.1
-layout: indicator
-permalink: /17-9-1/
----
-
-

--- a/_indicators/2-1-1.md
+++ b/_indicators/2-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 2.1.1
-layout: indicator
-permalink: /2-1-1/
----
-
-

--- a/_indicators/2-1-2.md
+++ b/_indicators/2-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 2.1.2
-layout: indicator
-permalink: /2-1-2/
----
-
-

--- a/_indicators/2-2-1.md
+++ b/_indicators/2-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 2.2.1
-layout: indicator
-permalink: /2-2-1/
----
-
-

--- a/_indicators/2-2-2.md
+++ b/_indicators/2-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 2.2.2
-layout: indicator
-permalink: /2-2-2/
----
-
-

--- a/_indicators/2-3-1.md
+++ b/_indicators/2-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 2.3.1
-layout: indicator
-permalink: /2-3-1/
----
-
-

--- a/_indicators/2-3-2.md
+++ b/_indicators/2-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 2.3.2
-layout: indicator
-permalink: /2-3-2/
----
-
-

--- a/_indicators/2-4-1.md
+++ b/_indicators/2-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 2.4.1
-layout: indicator
-permalink: /2-4-1/
----
-
-

--- a/_indicators/2-a-1.md
+++ b/_indicators/2-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 2.a.1
-layout: indicator
-permalink: /2-a-1/
----
-
-

--- a/_indicators/2-a-2.md
+++ b/_indicators/2-a-2.md
@@ -1,7 +1,0 @@
----
-indicator: 2.a.2
-layout: indicator
-permalink: /2-a-2/
----
-
-

--- a/_indicators/3-1-1.md
+++ b/_indicators/3-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.1.1
-layout: indicator
-permalink: /3-1-1/
----
-
-

--- a/_indicators/3-1-2.md
+++ b/_indicators/3-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.1.2
-layout: indicator
-permalink: /3-1-2/
----
-
-

--- a/_indicators/3-2-1.md
+++ b/_indicators/3-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.2.1
-layout: indicator
-permalink: /3-2-1/
----
-
-

--- a/_indicators/3-2-2.md
+++ b/_indicators/3-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.2.2
-layout: indicator
-permalink: /3-2-2/
----
-
-

--- a/_indicators/3-3-1.md
+++ b/_indicators/3-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.3.1
-layout: indicator
-permalink: /3-3-1/
----
-
-

--- a/_indicators/3-3-2.md
+++ b/_indicators/3-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.3.2
-layout: indicator
-permalink: /3-3-2/
----
-
-

--- a/_indicators/3-3-3.md
+++ b/_indicators/3-3-3.md
@@ -1,7 +1,0 @@
----
-indicator: 3.3.3
-layout: indicator
-permalink: /3-3-3/
----
-
-

--- a/_indicators/3-3-4.md
+++ b/_indicators/3-3-4.md
@@ -1,7 +1,0 @@
----
-indicator: 3.3.4
-layout: indicator
-permalink: /3-3-4/
----
-
-

--- a/_indicators/3-3-5.md
+++ b/_indicators/3-3-5.md
@@ -1,7 +1,0 @@
----
-indicator: 3.3.5
-layout: indicator
-permalink: /3-3-5/
----
-
-

--- a/_indicators/3-4-1.md
+++ b/_indicators/3-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.4.1
-layout: indicator
-permalink: /3-4-1/
----
-
-

--- a/_indicators/3-4-2.md
+++ b/_indicators/3-4-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.4.2
-layout: indicator
-permalink: /3-4-2/
----
-
-

--- a/_indicators/3-5-1.md
+++ b/_indicators/3-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.5.1
-layout: indicator
-permalink: /3-5-1/
----
-
-

--- a/_indicators/3-5-2.md
+++ b/_indicators/3-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.5.2
-layout: indicator
-permalink: /3-5-2/
----
-
-

--- a/_indicators/3-6-1.md
+++ b/_indicators/3-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.6.1
-layout: indicator
-permalink: /3-6-1/
----
-
-

--- a/_indicators/3-7-1.md
+++ b/_indicators/3-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.7.1
-layout: indicator
-permalink: /3-7-1/
----
-
-

--- a/_indicators/3-7-2.md
+++ b/_indicators/3-7-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.7.2
-layout: indicator
-permalink: /3-7-2/
----
-
-

--- a/_indicators/3-8-1.md
+++ b/_indicators/3-8-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.8.1
-layout: indicator
-permalink: /3-8-1/
----
-
-

--- a/_indicators/3-8-2.md
+++ b/_indicators/3-8-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.8.2
-layout: indicator
-permalink: /3-8-2/
----
-
-

--- a/_indicators/3-9-1.md
+++ b/_indicators/3-9-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.9.1
-layout: indicator
-permalink: /3-9-1/
----
-
-

--- a/_indicators/3-9-2.md
+++ b/_indicators/3-9-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.9.2
-layout: indicator
-permalink: /3-9-2/
----
-
-

--- a/_indicators/3-9-3.md
+++ b/_indicators/3-9-3.md
@@ -1,7 +1,0 @@
----
-indicator: 3.9.3
-layout: indicator
-permalink: /3-9-3/
----
-
-

--- a/_indicators/3-a-1.md
+++ b/_indicators/3-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.a.1
-layout: indicator
-permalink: /3-a-1/
----
-
-

--- a/_indicators/3-b-1.md
+++ b/_indicators/3-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.b.1
-layout: indicator
-permalink: /3-b-1/
----
-
-

--- a/_indicators/3-b-2.md
+++ b/_indicators/3-b-2.md
@@ -1,7 +1,0 @@
----
-indicator: 3.b.2
-layout: indicator
-permalink: /3-b-2/
----
-
-

--- a/_indicators/3-b-3.md
+++ b/_indicators/3-b-3.md
@@ -1,7 +1,0 @@
----
-indicator: 3.b.3
-layout: indicator
-permalink: /3-b-3/
----
-
-

--- a/_indicators/3-c-1.md
+++ b/_indicators/3-c-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.c.1
-layout: indicator
-permalink: /3-c-1/
----
-
-

--- a/_indicators/3-d-1.md
+++ b/_indicators/3-d-1.md
@@ -1,7 +1,0 @@
----
-indicator: 3.d.1
-layout: indicator
-permalink: /3-d-1/
----
-
-

--- a/_indicators/4-1-1.md
+++ b/_indicators/4-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.1.1
-layout: indicator
-permalink: /4-1-1/
----
-
-

--- a/_indicators/4-2-1.md
+++ b/_indicators/4-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.2.1
-layout: indicator
-permalink: /4-2-1/
----
-
-

--- a/_indicators/4-2-2.md
+++ b/_indicators/4-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 4.2.2
-layout: indicator
-permalink: /4-2-2/
----
-
-

--- a/_indicators/4-3-1.md
+++ b/_indicators/4-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.3.1
-layout: indicator
-permalink: /4-3-1/
----
-
-

--- a/_indicators/4-4-1.md
+++ b/_indicators/4-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.4.1
-layout: indicator
-permalink: /4-4-1/
----
-
-

--- a/_indicators/4-5-1.md
+++ b/_indicators/4-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.5.1
-layout: indicator
-permalink: /4-5-1/
----
-
-

--- a/_indicators/4-6-1.md
+++ b/_indicators/4-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.6.1
-layout: indicator
-permalink: /4-6-1/
----
-
-

--- a/_indicators/4-7-1.md
+++ b/_indicators/4-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.7.1
-layout: indicator
-permalink: /4-7-1/
----
-
-

--- a/_indicators/4-a-1.md
+++ b/_indicators/4-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.a.1
-layout: indicator
-permalink: /4-a-1/
----
-
-

--- a/_indicators/4-b-1.md
+++ b/_indicators/4-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 4.b.1
-layout: indicator
-permalink: /4-b-1/
----
-
-

--- a/_indicators/5-1-1.md
+++ b/_indicators/5-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.1.1
-layout: indicator
-permalink: /5-1-1/
----
-
-

--- a/_indicators/5-2-1.md
+++ b/_indicators/5-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.2.1
-layout: indicator
-permalink: /5-2-1/
----
-
-

--- a/_indicators/5-2-2.md
+++ b/_indicators/5-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 5.2.2
-layout: indicator
-permalink: /5-2-2/
----
-
-

--- a/_indicators/5-3-1.md
+++ b/_indicators/5-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.3.1
-layout: indicator
-permalink: /5-3-1/
----
-
-

--- a/_indicators/5-3-2.md
+++ b/_indicators/5-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 5.3.2
-layout: indicator
-permalink: /5-3-2/
----
-
-

--- a/_indicators/5-4-1.md
+++ b/_indicators/5-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.4.1
-layout: indicator
-permalink: /5-4-1/
----
-
-

--- a/_indicators/5-5-1.md
+++ b/_indicators/5-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.5.1
-layout: indicator
-permalink: /5-5-1/
----
-
-

--- a/_indicators/5-5-2.md
+++ b/_indicators/5-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 5.5.2
-layout: indicator
-permalink: /5-5-2/
----
-
-

--- a/_indicators/5-6-1.md
+++ b/_indicators/5-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.6.1
-layout: indicator
-permalink: /5-6-1/
----
-
-

--- a/_indicators/5-6-2.md
+++ b/_indicators/5-6-2.md
@@ -1,7 +1,0 @@
----
-indicator: 5.6.2
-layout: indicator
-permalink: /5-6-2/
----
-
-

--- a/_indicators/5-a-1.md
+++ b/_indicators/5-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.a.1
-layout: indicator
-permalink: /5-a-1/
----
-
-

--- a/_indicators/5-a-2.md
+++ b/_indicators/5-a-2.md
@@ -1,7 +1,0 @@
----
-indicator: 5.a.2
-layout: indicator
-permalink: /5-a-2/
----
-
-

--- a/_indicators/5-b-1.md
+++ b/_indicators/5-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.b.1
-layout: indicator
-permalink: /5-b-1/
----
-
-

--- a/_indicators/5-c-1.md
+++ b/_indicators/5-c-1.md
@@ -1,7 +1,0 @@
----
-indicator: 5.c.1
-layout: indicator
-permalink: /5-c-1/
----
-
-

--- a/_indicators/5-x-1.md
+++ b/_indicators/5-x-1.md
@@ -1,6 +1,0 @@
----
-indicator: 5.x.1
-layout: indicator
-permalink: /5-x-1/
----
-

--- a/_indicators/6-1-1.md
+++ b/_indicators/6-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.1.1
-layout: indicator
-permalink: /6-1-1/
----
-
-

--- a/_indicators/6-2-1.md
+++ b/_indicators/6-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.2.1
-layout: indicator
-permalink: /6-2-1/
----
-
-

--- a/_indicators/6-3-1.md
+++ b/_indicators/6-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.3.1
-layout: indicator
-permalink: /6-3-1/
----
-
-

--- a/_indicators/6-3-2.md
+++ b/_indicators/6-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 6.3.2
-layout: indicator
-permalink: /6-3-2/
----
-
-

--- a/_indicators/6-4-1.md
+++ b/_indicators/6-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.4.1
-layout: indicator
-permalink: /6-4-1/
----
-
-

--- a/_indicators/6-4-2.md
+++ b/_indicators/6-4-2.md
@@ -1,7 +1,0 @@
----
-indicator: 6.4.2
-layout: indicator
-permalink: /6-4-2/
----
-
-

--- a/_indicators/6-5-1.md
+++ b/_indicators/6-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.5.1
-layout: indicator
-permalink: /6-5-1/
----
-
-

--- a/_indicators/6-5-2.md
+++ b/_indicators/6-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 6.5.2
-layout: indicator
-permalink: /6-5-2/
----
-
-

--- a/_indicators/6-6-1.md
+++ b/_indicators/6-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.6.1
-layout: indicator
-permalink: /6-6-1/
----
-
-

--- a/_indicators/6-a-1.md
+++ b/_indicators/6-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.a.1
-layout: indicator
-permalink: /6-a-1/
----
-
-

--- a/_indicators/6-b-1.md
+++ b/_indicators/6-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 6.b.1
-layout: indicator
-permalink: /6-b-1/
----
-
-

--- a/_indicators/7-1-1.md
+++ b/_indicators/7-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 7.1.1
-layout: indicator
-permalink: /7-1-1/
----
-
-

--- a/_indicators/7-1-2.md
+++ b/_indicators/7-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 7.1.2
-layout: indicator
-permalink: /7-1-2/
----
-
-

--- a/_indicators/7-2-1.md
+++ b/_indicators/7-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 7.2.1
-layout: indicator
-permalink: /7-2-1/
----
-
-

--- a/_indicators/7-3-1.md
+++ b/_indicators/7-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 7.3.1
-layout: indicator
-permalink: /7-3-1/
----
-
-

--- a/_indicators/7-a-1.md
+++ b/_indicators/7-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 7.a.1
-layout: indicator
-permalink: /7-a-1/
----
-
-

--- a/_indicators/7-b-1.md
+++ b/_indicators/7-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 7.b.1
-layout: indicator
-permalink: /7-b-1/
----
-
-

--- a/_indicators/8-1-1.md
+++ b/_indicators/8-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.1.1
-layout: indicator
-permalink: /8-1-1/
----
-
-

--- a/_indicators/8-10-1.md
+++ b/_indicators/8-10-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.10.1
-layout: indicator
-permalink: /8-10-1/
----
-
-

--- a/_indicators/8-10-2.md
+++ b/_indicators/8-10-2.md
@@ -1,7 +1,0 @@
----
-indicator: 8.10.2
-layout: indicator
-permalink: /8-10-2/
----
-
-

--- a/_indicators/8-2-1.md
+++ b/_indicators/8-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.2.1
-layout: indicator
-permalink: /8-2-1/
----
-
-

--- a/_indicators/8-3-1.md
+++ b/_indicators/8-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.3.1
-layout: indicator
-permalink: /8-3-1/
----
-
-

--- a/_indicators/8-3-2.md
+++ b/_indicators/8-3-2.md
@@ -1,6 +1,0 @@
----
-indicator: 8.3.2
-layout: indicator
-permalink: /8-3-2/
----
-

--- a/_indicators/8-4-1.md
+++ b/_indicators/8-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.4.1
-layout: indicator
-permalink: /8-4-1/
----
-
-

--- a/_indicators/8-4-2.md
+++ b/_indicators/8-4-2.md
@@ -1,7 +1,0 @@
----
-indicator: 8.4.2
-layout: indicator
-permalink: /8-4-2/
----
-
-

--- a/_indicators/8-5-1.md
+++ b/_indicators/8-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.5.1
-layout: indicator
-permalink: /8-5-1/
----
-
-

--- a/_indicators/8-5-2.md
+++ b/_indicators/8-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 8.5.2
-layout: indicator
-permalink: /8-5-2/
----
-
-

--- a/_indicators/8-6-1.md
+++ b/_indicators/8-6-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.6.1
-layout: indicator
-permalink: /8-6-1/
----
-
-

--- a/_indicators/8-7-1.md
+++ b/_indicators/8-7-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.7.1
-layout: indicator
-permalink: /8-7-1/
----
-
-

--- a/_indicators/8-8-1.md
+++ b/_indicators/8-8-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.8.1
-layout: indicator
-permalink: /8-8-1/
----
-
-

--- a/_indicators/8-8-2.md
+++ b/_indicators/8-8-2.md
@@ -1,7 +1,0 @@
----
-indicator: 8.8.2
-layout: indicator
-permalink: /8-8-2/
----
-
-

--- a/_indicators/8-9-1.md
+++ b/_indicators/8-9-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.9.1
-layout: indicator
-permalink: /8-9-1/
----
-
-

--- a/_indicators/8-9-2.md
+++ b/_indicators/8-9-2.md
@@ -1,7 +1,0 @@
----
-indicator: 8.9.2
-layout: indicator
-permalink: /8-9-2/
----
-
-

--- a/_indicators/8-b-1.md
+++ b/_indicators/8-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 8.b.1
-layout: indicator
-permalink: /8-b-1/
----
-
-

--- a/_indicators/9-1-1.md
+++ b/_indicators/9-1-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.1.1
-layout: indicator
-permalink: /9-1-1/
----
-
-

--- a/_indicators/9-1-2.md
+++ b/_indicators/9-1-2.md
@@ -1,7 +1,0 @@
----
-indicator: 9.1.2
-layout: indicator
-permalink: /9-1-2/
----
-
-

--- a/_indicators/9-2-1.md
+++ b/_indicators/9-2-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.2.1
-layout: indicator
-permalink: /9-2-1/
----
-
-

--- a/_indicators/9-2-2.md
+++ b/_indicators/9-2-2.md
@@ -1,7 +1,0 @@
----
-indicator: 9.2.2
-layout: indicator
-permalink: /9-2-2/
----
-
-

--- a/_indicators/9-3-1.md
+++ b/_indicators/9-3-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.3.1
-layout: indicator
-permalink: /9-3-1/
----
-
-

--- a/_indicators/9-3-2.md
+++ b/_indicators/9-3-2.md
@@ -1,7 +1,0 @@
----
-indicator: 9.3.2
-layout: indicator
-permalink: /9-3-2/
----
-
-

--- a/_indicators/9-4-1.md
+++ b/_indicators/9-4-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.4.1
-layout: indicator
-permalink: /9-4-1/
----
-
-

--- a/_indicators/9-5-1.md
+++ b/_indicators/9-5-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.5.1
-layout: indicator
-permalink: /9-5-1/
----
-
-

--- a/_indicators/9-5-2.md
+++ b/_indicators/9-5-2.md
@@ -1,7 +1,0 @@
----
-indicator: 9.5.2
-layout: indicator
-permalink: /9-5-2/
----
-
-

--- a/_indicators/9-a-1.md
+++ b/_indicators/9-a-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.a.1
-layout: indicator
-permalink: /9-a-1/
----
-
-

--- a/_indicators/9-b-1.md
+++ b/_indicators/9-b-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.b.1
-layout: indicator
-permalink: /9-b-1/
----
-
-

--- a/_indicators/9-c-1.md
+++ b/_indicators/9-c-1.md
@@ -1,7 +1,0 @@
----
-indicator: 9.c.1
-layout: indicator
-permalink: /9-c-1/
----
-
-

--- a/_pages/admin.md
+++ b/_pages/admin.md
@@ -12,4 +12,4 @@ The National Reporting Platform is managed through GitHub. To submit updates for
 
 #### Intitialize Your Account
 
-If you've never authorized your GitHub account to make edits on this website, please go to the [account page](http://prose.io/#{{site.org_name}}/{{site.repo_name}}/edit/development/account.md) and click the green button in the bottom right corner of the screen and follow the next prompt.
+If you've never authorized your GitHub account to make edits on this website, please go to the [account page](http://prose.io/#{{site.org_name}}/{{site.repo_name}}/edit/gh-pages/account.md) and click the green button in the bottom right corner of the screen and follow the next prompt.

--- a/_pages/disconnectedyouth.md
+++ b/_pages/disconnectedyouth.md
@@ -1,0 +1,5 @@
+---
+layout: disconnectedyouth
+title: Disconnected Youth
+permalink: /disconnectedyouth/
+---

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,5 +1,0 @@
----
-title: Welcome
-permalink: /
-layout: frontpage
----

--- a/_pages/indicators.json
+++ b/_pages/indicators.json
@@ -1,4 +1,0 @@
----
-layout: indicator-json
-permalink: /indicators.json
----

--- a/_pages/reporting-status.md
+++ b/_pages/reporting-status.md
@@ -1,6 +1,0 @@
----
-layout: page
-title: Data Summary
-permalink: /reporting-status/
-layout: reportingstatus
----

--- a/_pages/search.md
+++ b/_pages/search.md
@@ -1,5 +1,0 @@
----
-title: Search
-permalink: /search/
-layout: search
----


### PR DESCRIPTION
### What does this PR do?

This PR brings over the latest files from Dawn's open-sdg-site-starter repository, https://github.com/dawncomer/open-sdg-site-starter, commit a5f2f08b6fe5303005ccfc7c18dbcb0ccb530c33. It also includes the fixes necessary for proper prose.io integration for the development environment.

### Additional Background info:

We discovered that the `edit` buttons on the indicator pages do not show unless the `environment` key-value pair in the `_config.yml` is set to `staging`. Any other value will not result in the `edit` buttons from appearing in the development environment. According to the open-sdg documentation, they refer the environment as staging while we are referring it as the development environment.

### How was this tested?

Changes made in this PR have been tested by running `bundle exec jekyll serve --config _config.yml`. This serves the dev version of the site. Visit `http://127.0.0.1:4000/` to make sure the home page is served as expected. Also, visit `http://127.0.0.1:4000/1-1-1/#edit` to have the buttons appear to edit the data. Click on one of the buttons and it will take you to prose.io to edit the appropriate data file for the given indicator on the `development` branch of the data repository.

You may also test that the production version builds successfully by running `bundle exec jekyll serve --config _config.yml,_config_prod.yml`.

### Issue(s) related to this PR?

This PR is related to issue #10 

close #10 