### PR TITLE
ci(runner): Development Workflow - Add repository_dispatch Trigger

### DIFF
--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -8,8 +8,9 @@ on: # run this workflow when a push has been made to `development` branch
   push:
     branches:
       - development
+# Listen for repository dispatch event from open-sdg-data-starter workflow
+  repository_dispatch
  
-
 jobs:
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -9,6 +9,7 @@ on: # run this workflow when a push has been made to `development` branch
     branches:
       - development
 # Listen for repository dispatch event from open-sdg-data-starter workflow
+on:
   repository_dispatch
  
 jobs:


### PR DESCRIPTION
### What does this MR do?

- (Development Workflow) Add repository_dispatch trigger

### Background info

open-sdg-data-starter will trigger workflow in this repo, a trigger needs to be setup to listen for the event.

Resources used:
https://github.community/t/triggering-by-other-repository/16163
https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event

### How can this be tested (manually and/or automated test)?

Will be tested once merged.

### Which issue(s) is/are related to this PR?

This PR is/are related to issue(s) issue #17 