### PR TITLE
ci(runner): Specify Branches to Checkout

### DIFF
--- a/.github/workflows/BuildNDeployDev.yml
+++ b/.github/workflows/BuildNDeployDev.yml
@@ -20,6 +20,8 @@ jobs:
  ###########################################################################################################
         - name: Checkout repo
           uses: actions/checkout@v2
+          with:
+            ref: development
         
         - name: Setup Ruby
           uses: actions/setup-ruby@v1

--- a/.github/workflows/BuildNDeployProd.yml
+++ b/.github/workflows/BuildNDeployProd.yml
@@ -21,6 +21,8 @@ jobs:
  ###########################################################################################################
         - name: Checkout repo
           uses: actions/checkout@v2
+          with:
+            ref: production
         
         - name: Setup Ruby
           uses: actions/setup-ruby@v1


### PR DESCRIPTION
### What does this MR do?

- (Development/Production Workflow) Add specific branch to checkout

### Background info

Triggering workflow using repository_dispatch means that the prod workflow can checkout the code in the dev branch, as the prod workflow is triggered from the dev default branch. To fix this, specify branches in each pipeline to checkout.

### How can this be tested (manually and/or automated test)?

Will be tested once merged.

### Which issue(s) is/are related to this PR?

This PR is/are related to issue(s) issue #19 

close #19